### PR TITLE
Avoid rate limiting on JobShow pages and scrape index with headless

### DIFF
--- a/app/services/index_pages/doors_open.rb
+++ b/app/services/index_pages/doors_open.rb
@@ -9,7 +9,7 @@ module IndexPages
   class DoorsOpen
     def self.call
       # Open a browser
-      browser = Watir::Browser.new
+      browser = Watir::Browser.new :chrome, headless: true
 
       # Navigate to the target index
       browser.goto 'https://www.doorsopen.co/jobs/?q=&l=London%2C+UK'

--- a/app/services/show_pages/doors_open.rb
+++ b/app/services/show_pages/doors_open.rb
@@ -4,27 +4,47 @@ require 'httparty'
 require 'nokogiri'
 
 module ShowPages
-  # Scraps a webpage and saves the
-  # result as a JobShow
+  # Scraps a webpage and returns
+  # an object with job attributes
   class DoorsOpen
+    Result = Struct.new(
+      :company_name,
+      :url,
+      :title,
+      keyword_init: true
+    )
+
     def self.call(url)
-      # Downloading target web page
-      response = HTTParty.get(url)
+      attempts = 0
+      max_attempts = 3
 
-      # Parsing the HTML document returned by the server
-      doc = Nokogiri::HTML(response.body)
+      while attempts < max_attempts
+        # Downloading target web page
+        sleep rand(300)
+        response = HTTParty.get(url)
 
-      # Extract ob title
-      title = doc.css('.details-header__title').text.strip
+        # Parsing the HTML document returned by the server
+        doc = Nokogiri::HTML(response.body)
 
-      Struct.new('Result', :company_name, :title)
+        # Extract title
+        title = doc.css('.details-header__title').text.strip
 
-      # Return object
-      Struct::Result.new(
-        company_name: 'Doors Open',
-        url:,
-        title:
-      )
+        if response.code == 200
+
+          # Return object when successful
+          return Result.new(
+            company_name: 'Doors Open',
+            url:,
+            title:
+          )
+        else
+          sleep rand(300)
+          attempts += 1
+        end
+      end
+
+      # return nil when failed
+      nil
     end
   end
 end

--- a/app/sidekiq/scrape_job_show_job.rb
+++ b/app/sidekiq/scrape_job_show_job.rb
@@ -4,12 +4,17 @@
 class ScrapeJobShowJob
   include Sidekiq::Job
 
-  def perform(script:, url:)
+  def perform(id)
+    record = JobShow.find(id)
+
     # Instantiate object
-    script = Object.const_get(script)
+    script = Object.const_get(record.script)
 
     # Scrape webspage and return result
-    attributes = script.call(url:)
+    attributes = script.call(record.url)
+
+    # Early return if script return nil
+    return if attributes.nil?
 
     # Find or create job record
     SaveJob.call(attributes)

--- a/spec/factories/job_shows.rb
+++ b/spec/factories/job_shows.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :JobShow do
     company { Faker::Company.name }
     url { Faker::Internet.url }
-    script { '/script.rb' }
+    script { 'JobShowPageScript' }
   end
 end

--- a/spec/sidekiq/scrape_job_show_job_spec.rb
+++ b/spec/sidekiq/scrape_job_show_job_spec.rb
@@ -8,7 +8,7 @@ require 'sidekiq/testing'
 # show page of a site
 # e.g doorsopen.com
 class JobShowPageScript
-  def self.call(url:); end
+  def self.call(url); end
 end
 
 # Tests the show page job. The call to the
@@ -18,15 +18,15 @@ RSpec.describe ScrapeJobShowJob, type: :job do
   include ActiveSupport::Testing::TimeHelpers
 
   describe '#perform' do
-    let(:url) { 'https://www.example.com' }
-    let(:attributes) { OpenStruct.new(company_name: 'NVS', title: 'Ticketing Manager', url:) }
+    let(:attributes) { OpenStruct.new(company_name: 'NVS', title: 'Ticketing Manager', url: 'url') }
     let(:script) { JobShowPageScript }
+    let(:job_show) { create(:JobShow) }
 
     before { allow(script).to receive(:call).and_return(attributes) }
 
     context 'when given attributes of a new job' do
       it 'creates a new job record' do
-        expect { subject.perform(script: script.name, url:) }
+        expect { subject.perform(job_show.id) }
           .to change(Job, :count).by(1)
 
         expect(Job.last).to have_attributes(
@@ -39,10 +39,10 @@ RSpec.describe ScrapeJobShowJob, type: :job do
       describe 'when give attributes of an existing job' do
         it 'finds and updates the job' do
           travel_to(1.month.ago)
-          Job.create(company_name: 'job record', title: 'that exists already', url:)
+          Job.create(company_name: 'job record', title: 'that exists already', url: 'url')
           travel_back
 
-          expect { subject.perform(script: script.name, url:) }
+          expect { subject.perform(job_show.id) }
             .to change(Job, :count).by(0)
         end
       end


### PR DESCRIPTION
The script now checks the response and loops to try and get a 200 response. 
Sleep is used to randomise the request time to DoorsOpen to help prevent rate limiting. 